### PR TITLE
[WILL NOT MERGE] Bot command for list of perfected games of a given user

### DIFF
--- a/src/bot_helper.py
+++ b/src/bot_helper.py
@@ -52,11 +52,11 @@ def users_game_stats(user: str, game_name: str) -> Stats:
     description1 = f"[{user}]({steam_api.get_user_url(user)}) has a total of {total_hours} hours " \
                    f"played on [{game_name}]({steam_api.get_game_url(game_id)})! "
     player_achievements = steam_api.get_player_achievements(user_id, game_id)
-    if player_achievements == 'No_Game':
+    if player_achievements.unlocked == 0:
         description2 = f"[{user}]({steam_api.get_user_url(user)}) has unlocked 0 achievements"
-    elif player_achievements == 'No_Achievements':
+    elif player_achievements.status == 'No_Achievements':
         description2 = f"[{game_name}]({steam_api.get_game_url(game_id)}) does not have any achievements to unlock."
-    elif player_achievements == 'Private_Profile':
+    elif player_achievements.status == 'Private_Profile':
         description2 = f"[{user}]({steam_api.get_user_url(user)}) has their unlocked achievements private."
     else:
         description2 = f"[{user}]({steam_api.get_user_url(user)}) has unlocked " \
@@ -108,7 +108,7 @@ def game_desc(game_name: str) -> Stats:
     return Stats(name=game_name, description1=description1, description2=description2, icon=steam_api.get_game_icon(game_id))
 
 
-def get_top_x_games(x: int) -> Stats:
+def top_x_games(x: int) -> Stats:
     if x > 100:
         raise ExceedingTopGamesMax("Can only search up to a maximum of the top 100 games.")
     else:
@@ -120,3 +120,18 @@ def get_top_x_games(x: int) -> Stats:
             description2 += f'#{top100games.index(game) + 1} {game["name"]}'\
                             f' with {formatter.format_numbers_with_comma(game["player_count"])} players\n'
         return Stats(name=title, description1=description1, description2=description2, icon=steam_api.get_steam_icon())
+
+
+def perfect_games(user: str) -> Stats:
+    user_id = get_user_id(user)
+    player_summary = steam_api.get_player_summaries(user_id)
+    games = steam_api.get_perfect_games(user_id)
+    if games == 'Private_Profile':
+        return Stats(name=user, description1=f"[{user}]({steam_api.get_user_url(user)}) has their unlocked achievements private.", icon=player_summary.avatarfull)
+    else:
+        description1 = f"[{user}]({steam_api.get_user_url(user)}) has perfected {len(games)} games on Steam."
+        if len(games) > 0:
+            description2 = "Those games and their total amount of achievements are: \n"
+            for key in games:
+                description2 += f'   - {key} with a total of {games[key]} achievements \n'
+        return Stats(name=user, description1=description1, icon=player_summary.avatarfull)

--- a/src/main.py
+++ b/src/main.py
@@ -118,7 +118,7 @@ def main():
     )
     async def top(ctx, *, arg: int):
         try:
-            stats = bot_helper.get_top_x_games(arg)
+            stats = bot_helper.top_x_games(arg)
             embed = discord.Embed(title=f"{stats.name}",
                                   description=f"{stats.description1}\n\n"
                                               f"{stats.description2}",
@@ -126,6 +126,20 @@ def main():
             embed.set_thumbnail(url=f"{stats.icon}")
             await ctx.send(embed=embed)
         except ExceedingTopGamesMax as exc:
+            await ctx.send(exc)
+
+    @bot.command(
+        name="perfect", description="Prints a user's perfected games"
+    )
+    async def perfect(ctx, *, arg: str):
+        try:
+            stats = bot_helper.perfect_games(arg)
+            embed = discord.Embed(title=f"{stats.name}",
+                                  description=f"{stats.description1}",
+                                  color=discord.Colour.blue())
+            embed.set_thumbnail(url=f"{stats.icon}")
+            await ctx.send(embed=embed)
+        except UserIsNoneError as exc:
             await ctx.send(exc)
 
     @bot.event

--- a/src/models/PlayerAchievements.py
+++ b/src/models/PlayerAchievements.py
@@ -1,7 +1,11 @@
 from dataclasses import dataclass
+from dataclasses import field
+from typing import Optional
 
 
 @dataclass(frozen=True)
 class PlayerAchievements:
     unlocked: int
     total: int
+    game_name: Optional[str] = field(default=None)
+    status: Optional[str] = field(default=None)

--- a/src/models/Stats.py
+++ b/src/models/Stats.py
@@ -1,9 +1,11 @@
 from dataclasses import dataclass
+from dataclasses import field
+from typing import Optional
 
 
 @dataclass(frozen=True)
 class Stats:
     name: str
     description1: str
-    description2: str
-    icon: str
+    description2: Optional[str] = field(default=None)
+    icon: Optional[str] = field(default=None)

--- a/tests/test_steam_api.py
+++ b/tests/test_steam_api.py
@@ -4,6 +4,7 @@ from src.models.AchievementPercent import AchievementPercent
 from src.models.Players import Players
 from src.models.Game import Game
 from src.models.AchievementPercent import AchievementPercent
+from src.models.PlayerAchievements import PlayerAchievements
 from src.models.AchievementDetails import AchievementDetails
 from src.models.Playtime import Playtime
 from src.steam_api import SteamApi
@@ -203,7 +204,7 @@ class TestGetPlayerAchievements:
         steam_api = SteamApi(mock_request_client)
         actual_player_achievements = steam_api.get_player_achievements(76561198094936897,
                                                                        1172620)  # IDs for user "xAmpharosx" and game "Sea of Thieves"
-        expected_player_achievements = 'No_Game'
+        expected_player_achievements = PlayerAchievements(unlocked=0, total=1)
 
         assert actual_player_achievements == expected_player_achievements
 
@@ -218,7 +219,7 @@ class TestGetPlayerAchievements:
         steam_api = SteamApi(mock_request_client)
         actual_player_achievements = steam_api.get_player_achievements(76561198004892682,
                                                                        1172620)  # IDs for user "DGamesta" and game "Sea of Thieves"
-        expected_player_achievements = 'Private_Profile'
+        expected_player_achievements = PlayerAchievements(unlocked=0, total=1, status='Private_Profile')
 
         assert actual_player_achievements == expected_player_achievements
 
@@ -233,7 +234,7 @@ class TestGetPlayerAchievements:
         steam_api = SteamApi(mock_request_client)
         actual_player_achievements = steam_api.get_player_achievements(76561198094936897,
                                                                        892970)  # IDs for user "xAmpharosx" and game "Valheim"
-        expected_player_achievements = 'No_Achievements'
+        expected_player_achievements = PlayerAchievements(unlocked=0, total=1, status='No_Achievements')
 
         assert actual_player_achievements == expected_player_achievements
 


### PR DESCRIPTION
**Leaving this PR opened and for now, will not merge** :

This PR introduces a bot command that prints a given user's perfected games.  That is, games they've unlocked every single achievement in.  Because there is not a single endpoint to grab this data, the way to preform this takes a minute or so to complete and actually times-out the response Discord is waiting for.  There may be a better way to write this where it won't take as long and time-out Discord.... so until than this PR will remain open as a "first approach".

What's actually being done is iterating through a list of every owned games of a given user and passing each one individually into the GetPlayerAchievements end point.  From there, iterating again through every single achievement and checking if the unlocked achievement key is equal to 1.  A dictionary is made of every game that has all achievements unlocked along with the total number of achievements. 